### PR TITLE
Update GetCmdLine offset for TF2 version 9247927 (2024-10-10)

### DIFF
--- a/accelerator.games.txt
+++ b/accelerator.games.txt
@@ -39,6 +39,13 @@
 				"windows" "\x55\x8B\xEC\x83\xEC\x20\x8D\x45\xE0\x53\x57\x6A\x01\x68\x49\x03\x00\x00"
 			}
 		}
+		"Offsets"
+		{
+			"GetCmdLine"
+			{
+				"windows" "4"
+			}
+		}
 	}
 
 	"cstrike"


### PR DESCRIPTION
Fixes #20.

Located by finding the call to `CommandLine_Tier0` in engine's `CDemoPlayer::WriteTimeDemoResults` (via string "%i frames %5.3f seconds %5.2f fps (%5.2f ms/f) %5.3f fps variability\n").

```diff
  ; CDemoPlayer::WriteTimeDemoResults
  call    ds:CommandLine_Tier0
  mov     ecx, dword_10639D98
  mov     edx, [eax]
  mov     edi, [ecx]
  mov     ecx, eax
- call    dword ptr [edx+8]
+ call    dword ptr [edx+10h]
```

Also matched via `Sys_TryInitSteamInfo` via string "DedicatedServerAPI ":

```diff
  call    edi ; CommandLine_Tier0
  mov     ecx, eax
  mov     edx, [eax]
- call    dword ptr [edx+8]
+ call    dword ptr [edx+10h]
  cmp     [ebp+arg_10], 0
  mov     ecx, offset byte_102EB556
  push    eax
  mov     eax, offset aDedicatedserve ; "DedicatedServerAPI "
  cmovz   eax, ecx
```

Linux is still at offset 2.

For server operators, you can place the modified file on the server as `gamedata/custom/accelerator.games.txt` for it to take priority in the meantime.